### PR TITLE
fixes #251

### DIFF
--- a/client/bootstrap
+++ b/client/bootstrap
@@ -163,7 +163,7 @@ def _exit(code):
         for path in [x for x in all_files('/mnt/flash')
                      if x not in FLASH_FILES]:
             log('Deleting %s...' % path)
-            if os.path.isdir(backup_path):
+            if os.path.isdir(path):
                 shutil.rmtree(path)
             else:
                 try:


### PR DESCRIPTION
The path variable should be used and not the backup_path variable since "all_files" returns full paths.
