### PR TITLE
Fix setup.py and ztpserver.spec so RPM can be built

### DIFF
--- a/rpm/ztpserver.spec
+++ b/rpm/ztpserver.spec
@@ -117,6 +117,7 @@ cp -rp $RPM_BUILD_DIR%{app_virtualenv_dir}/* $RPM_BUILD_ROOT%{app_virtualenv_dir
 # Force some paths for install to handle the virtual_env case for RHEL
 %{__install} -d $RPM_BUILD_ROOT%{python2_sitelib}
 PYTHONPATH=$RPM_BUILD_ROOT%{python2_sitelib}:${PYTHONPATH} \
+ZTPS_INSTALL_ROOT=$RPM_BUILD_ROOT \
 python setup.py install --root=$RPM_BUILD_ROOT  --install-scripts=%{_bindir} \
 --install-lib=%{python2_sitelib}
 
@@ -163,6 +164,7 @@ chcon -Rv --type=httpd_sys_content_t %{_datadir}/ztpserver
 %{_bindir}/ztps
 
 %dir %{_sysconfdir}/ztpserver
+%{_sysconfdir}/ztpserver/.VERSION
 %config(noreplace) %{_sysconfdir}/ztpserver/ztpserver.conf
 %config(noreplace) %{_sysconfdir}/ztpserver/ztpserver.wsgi
 %config(noreplace) %{httpd_dir}/%{name}-wsgi.conf

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ setup(
 if install():
     custom_path = os.environ.get('ZTPS_INSTALL_ROOT')
     if custom_path:
-        shutil.copy('VERSION', join_url(custom_path, config.VERSION_FILE_PATH)
+        shutil.copy('VERSION', join_url(custom_path, config.VERSION_FILE_PATH))
     else:   
         shutil.copy('VERSION', config.VERSION_FILE_PATH)
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ def install():
     else:
         return False
 
+def join_url(x, y):
+    return '/' + '/'.join([z for z in x.split('/') + y.split('/') if z])
+
 conf_path = config.CONF_PATH
 install_path = config.INSTALL_PATH
 
@@ -138,7 +141,7 @@ setup(
 if install():
     custom_path = os.environ.get('ZTPS_INSTALL_ROOT')
     if custom_path:
-        shutil.copy('VERSION', '%s%s' % (custom_path, config.VERSION_FILE_PATH))
+        shutil.copy('VERSION', join_url(custom_path, config.VERSION_FILE_PATH)
     else:   
         shutil.copy('VERSION', config.VERSION_FILE_PATH)
 

--- a/setup.py
+++ b/setup.py
@@ -134,8 +134,8 @@ setup(
     data_files=data_files
 )
 
- # hidden version file
- if install():
+# hidden version file
+if install():
     custom_path = os.environ.get('ZTPS_INSTALL_ROOT')
     if custom_path:
         shutil.copy('VERSION', '%s%s' % (custom_path, config.VERSION_FILE_PATH))

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,10 @@ except ImportError:
     from distutils.core import setup
 
 def install():
-    return sys.argv[1:] == ['install']
+    if "install" in sys.argv:
+        return True
+    else:
+        return False
 
 conf_path = config.CONF_PATH
 install_path = config.INSTALL_PATH
@@ -103,7 +106,7 @@ for filename in glob('actions/*'):
     file_list += [(filename.split('/')[-1],
                    '%s/actions' % install_path,
                    filename)]
-for filename in glob('clent/lib/*'):
+for filename in glob('client/lib/*'):
     file_list += [(filename.split('/')[-1],
                    '%s/files/lib' % install_path,
                    filename)]
@@ -131,6 +134,11 @@ setup(
     data_files=data_files
 )
 
-# hidden version file
-if install():
-    shutil.copy('VERSION', config.VERSION_FILE_PATH)
+ # hidden version file
+ if install():
+    custom_path = os.environ.get('ZTPS_INSTALL_ROOT')
+    if custom_path:
+        shutil.copy('VERSION', '%s%s' % (custom_path, config.VERSION_FILE_PATH))
+    else:   
+        shutil.copy('VERSION', config.VERSION_FILE_PATH)
+


### PR DESCRIPTION
setup.py
 - Fix #279 - Modify install() function so setup.py can take other args
 - Fix #280 - Fixes typo in clent -> client
ztpserver.spec
 - Add envvar ZTPS_INSTALL_ROOT which allows some copies to work
 - Add %{_sysconfdir}/ztpserver/.VERSION to package new hidden file