### PR TITLE
Fix rpmbuild to work with updated setup.py

### DIFF
--- a/rpm/ztpserver.spec
+++ b/rpm/ztpserver.spec
@@ -164,6 +164,7 @@ chcon -Rv --type=httpd_sys_content_t %{_datadir}/ztpserver
 rm -rf /etc/ztpserver
 rm -rf /usr/share/ztpserver
 rm -rf /usr/bin/ztps
+rm -rf %{httpd_dir}/%{name}-wsgi.conf
 
 %files
 # all the files to be included in this RPM:

--- a/rpm/ztpserver.spec
+++ b/rpm/ztpserver.spec
@@ -32,7 +32,7 @@ URL:      %{app_url}
 Source0:  %{name}-%{version}.tgz
 Source1:  %{name}-wsgi.conf
 
-### Don't allow rpmbuild to modify dependencies 
+### Don't allow rpmbuild to modify dependencies
 AutoReqProv: no
 
 BuildRequires: python-pip
@@ -77,10 +77,10 @@ ability to define the target node through the introduction of definitions and
 templates that call pre-built actions and statically defined or dynamically
 generated attributes. The attributes and actions can also be extended to provide
 custom functionality that are specific to a given implementation. ZTPServer also
-provides a topology validation engine with a simple syntax to express LLDP 
-neighbor adjacencies. It is written mostly in Python and leverages standard 
-protocols like DHCP and DHCP options for boot functions, HTTP for 
-bi-directional transport, and XMPP and syslog for logging. Most of the files 
+provides a topology validation engine with a simple syntax to express LLDP
+neighbor adjacencies. It is written mostly in Python and leverages standard
+protocols like DHCP and DHCP options for boot functions, HTTP for
+bi-directional transport, and XMPP and syslog for logging. Most of the files
 that the user interacts with are YAML based.
 
 %prep
@@ -118,7 +118,7 @@ cp -rp $RPM_BUILD_DIR%{app_virtualenv_dir}/* $RPM_BUILD_ROOT%{app_virtualenv_dir
 %{__install} -d $RPM_BUILD_ROOT%{python2_sitelib}
 PYTHONPATH=$RPM_BUILD_ROOT%{python2_sitelib}:${PYTHONPATH} \
 ZTPS_INSTALL_ROOT=$RPM_BUILD_ROOT \
-python setup.py install --root=$RPM_BUILD_ROOT  --install-scripts=%{_bindir} \
+python setup.py install --root=$RPM_BUILD_ROOT/%{app_virtualenv_dir}  --install-scripts=%{_bindir} \
 --install-lib=%{python2_sitelib}
 
 %{__install} -pD %{SOURCE1} $RPM_BUILD_ROOT%{httpd_dir}/%{name}-wsgi.conf
@@ -161,35 +161,37 @@ chcon -Rv --type=httpd_sys_content_t %{_datadir}/ztpserver
 # all the files to be included in this RPM:
 %defattr(-,root,root,)
 %if 0%{?rhel} == 6
+%defattr(-,%{app_user},%{app_user},)
 %{app_virtualenv_dir}
+%{app_virtualenv_dir}/bin/ztps
 %else
 %{python2_sitelib}/%{name}
 %{python2_sitelib}/%{name}-%{version}*.egg-info
+%{_bindir}/ztps
 %endif
 
-%{_bindir}/ztps
 
-%dir %{_sysconfdir}/ztpserver
-%{_sysconfdir}/ztpserver/.VERSION
-%config(noreplace) %{_sysconfdir}/ztpserver/ztpserver.conf
-%config(noreplace) %{_sysconfdir}/ztpserver/ztpserver.wsgi
+%dir %{app_virtualenv_dir}/%{_sysconfdir}/ztpserver
+%{app_virtualenv_dir}/%{_sysconfdir}/ztpserver/.VERSION
+%config(noreplace) %{app_virtualenv_dir}/%{_sysconfdir}/ztpserver/ztpserver.conf
+%config(noreplace) %{app_virtualenv_dir}/%{_sysconfdir}/ztpserver/ztpserver.wsgi
 %config(noreplace) %{httpd_dir}/%{name}-wsgi.conf
 
 %defattr(0775,%{app_user},%{app_user},)
-%dir %{_datadir}/ztpserver
-%dir %{_datadir}/ztpserver/actions
-%dir %{_datadir}/ztpserver/bootstrap
-%dir %{_datadir}/ztpserver/definitions
-%dir %{_datadir}/ztpserver/files
-%dir %{_datadir}/ztpserver/files/lib
-%dir %{_datadir}/ztpserver/nodes
-%dir %{_datadir}/ztpserver/resources
+%dir %{app_virtualenv_dir}/%{_datadir}/ztpserver
+%dir %{app_virtualenv_dir}/%{_datadir}/ztpserver/actions
+%dir %{app_virtualenv_dir}/%{_datadir}/ztpserver/bootstrap
+%dir %{app_virtualenv_dir}/%{_datadir}/ztpserver/definitions
+%dir %{app_virtualenv_dir}/%{_datadir}/ztpserver/files
+%dir %{app_virtualenv_dir}/%{_datadir}/ztpserver/files/lib
+%dir %{app_virtualenv_dir}/%{_datadir}/ztpserver/nodes
+%dir %{app_virtualenv_dir}/%{_datadir}/ztpserver/resources
 
 %defattr(0665,%{app_user},%{app_user},)
-%{_datadir}/ztpserver/files/lib/*
-%config(noreplace) %{_datadir}/ztpserver/actions/*
-%config(noreplace) %{_datadir}/ztpserver/bootstrap/*
-%config(noreplace) %{_datadir}/ztpserver/neighbordb
+%{app_virtualenv_dir}/%{_datadir}/ztpserver/files/lib/*
+%config(noreplace) %{app_virtualenv_dir}/%{_datadir}/ztpserver/actions/*
+%config(noreplace) %{app_virtualenv_dir}/%{_datadir}/ztpserver/bootstrap/*
+%config(noreplace) %{app_virtualenv_dir}/%{_datadir}/ztpserver/neighbordb
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/rpm/ztpserver.spec
+++ b/rpm/ztpserver.spec
@@ -180,10 +180,10 @@ rm -rf %{httpd_dir}/%{name}-wsgi.conf
 %endif
 %{_bindir}/ztps
 
-%dir %{app_virtualenv_dir}/%{_sysconfdir}/ztpserver
-%{app_virtualenv_dir}/%{_sysconfdir}/ztpserver/.VERSION
-%config(noreplace) %{app_virtualenv_dir}/%{_sysconfdir}/ztpserver/ztpserver.conf
-%config(noreplace) %{app_virtualenv_dir}/%{_sysconfdir}/ztpserver/ztpserver.wsgi
+%dir %{_sysconfdir}/ztpserver
+%{_sysconfdir}/ztpserver/.VERSION
+%config(noreplace) %{_sysconfdir}/ztpserver/ztpserver.conf
+%config(noreplace) %{_sysconfdir}/ztpserver/ztpserver.wsgi
 %config(noreplace) %{httpd_dir}/%{name}-wsgi.conf
 
 %defattr(0775,%{app_user},%{app_user},)

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,11 @@ def join_url(x, y):
 conf_path = config.CONF_PATH
 install_path = config.INSTALL_PATH
 
+if install() and os.environ.get('ZTPS_INSTALL_PREFIX'):
+    print "Customizing install for VirtualEnv install with RPM"
+    conf_path = join_url(os.environ.get('ZTPS_INSTALL_PREFIX'), config.CONF_PATH)
+    install_path = join_url(os.environ.get('ZTPS_INSTALL_PREFIX'), config.INSTALL_PATH)
+
 packages = ['ztpserver']
 if install() and os.environ.get('READTHEDOCS'):
     print 'Customizing install for ReadTheDocs.org build servers...'
@@ -101,7 +106,7 @@ for (filename, dst, src) in [('neighbordb',
 
     data_files += [(dst, glob(src))]
 
-# bootstrap file, libraries and actions are always
+# bootstrap file, libraries, VERSION and actions are always
 # overwritten
 file_list = [('bootstrap', '%s/bootstrap' % install_path, 
               'client/bootstrap')]
@@ -144,4 +149,3 @@ if install():
         shutil.copy('VERSION', join_url(custom_path, config.VERSION_FILE_PATH))
     else:   
         shutil.copy('VERSION', config.VERSION_FILE_PATH)
-


### PR DESCRIPTION
This also includes some enhancements to the ztpserver.spec file to put _all_ of the ztpserver-related files in the virtual_env.  Once in the virtual_env, symlinks are created to point to the typical system locations.  Also, new variables were created using system built-in macros to help simplify the %files macro of the rpm.