### PR TITLE
Fix setup.py install paths when on ReadTheDocs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ if install() and os.environ.get('READTHEDOCS'):
     conf_path = '.' + conf_path
     install_path = '.' +  install_path
     #config.VERSION_FILE_PATH = '.' + config.VERSION_FILE_PATH
-    os.environ('ZTPS_INSTALL_ROOT') = '.'
+    os.environ['ZTPS_INSTALL_ROOT'] = '.'
     from subprocess import call
     call(['docs/setup_rtd_files.sh'])
     packages.append('client')

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ setup(
 if install():
     custom_path = os.environ.get('ZTPS_INSTALL_ROOT')
     if custom_path:
-        version_file =  join_url(custom_path, config.VERSION_FILE_PATH)
+        version_file =  join_url(custom_path, config.VERSION_FILE_PATH)[1:]
     else:
         version_file =  config.VERSION_FILE_PATH
     ensure_dir(version_file)

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ if install() and os.environ.get('READTHEDOCS'):
     print 'Customizing install for ReadTheDocs.org build servers...'
     conf_path = '.' + conf_path
     install_path = '.' +  install_path
+    config.VERSION_FILE_PATH = '.' + config.VERSION_FILE_PATH
     from subprocess import call
     call(['docs/setup_rtd_files.sh'])
     packages.append('client')
@@ -75,7 +76,7 @@ version = None
 
 install_requirements = open('requirements.txt').read().split('\n')
 install_requirements = [x.strip() for x in install_requirements
-                        if x.strip() and 
+                        if x.strip() and
                         'dev only' not in x]
 version = open('VERSION').read().split()[0].strip()
 
@@ -89,8 +90,8 @@ for folder in ['nodes', 'definitions', 'files', 'resources',
             os.remove(path)
         data_files += [(path, [])]
 
-for (filename, dst, src) in [('neighbordb', 
-                              install_path, 
+for (filename, dst, src) in [('neighbordb',
+                              install_path,
                               'conf/neighbordb'),
                              ('bootstrap.conf',
                               '%s/bootstrap' % install_path,
@@ -104,7 +105,7 @@ for (filename, dst, src) in [('neighbordb',
     file_path = '%s/%s' % (dst, filename)
     if install() and os.path.exists(file_path):
         if os.path.isdir(file_path):
-            shutil.rmtree(file_path, 
+            shutil.rmtree(file_path,
                           ignore_errors=True)
         else:
             # do this manually
@@ -115,7 +116,7 @@ for (filename, dst, src) in [('neighbordb',
 
 # bootstrap file, libraries, VERSION, plugins and actions are
 # always overwritten
-file_list = [('bootstrap', '%s/bootstrap' % install_path, 
+file_list = [('bootstrap', '%s/bootstrap' % install_path,
               'client/bootstrap')]
 for filename in glob('actions/*'):
     file_list += [(filename.split('/')[-1],
@@ -133,7 +134,7 @@ for (filename, dst, src) in file_list:
     file_path = '%s/%s' % (dst, filename)
     if install() and os.path.exists(file_path) and \
             os.path.isdir(file_path):
-        shutil.rmtree(file_path, 
+        shutil.rmtree(file_path,
                       ignore_errors=True)
     data_files += [(dst, glob(src))]
 
@@ -158,5 +159,5 @@ if install():
     custom_path = os.environ.get('ZTPS_INSTALL_ROOT')
     if custom_path:
         shutil.copy('VERSION', join_url(custom_path, config.VERSION_FILE_PATH))
-    else:   
+    else:
         shutil.copy('VERSION', config.VERSION_FILE_PATH)

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ if install() and os.environ.get('READTHEDOCS'):
     print 'Customizing install for ReadTheDocs.org build servers...'
     conf_path = '.' + conf_path
     install_path = '.' +  install_path
-    #config.VERSION_FILE_PATH = '.' + config.VERSION_FILE_PATH
     os.environ['ZTPS_INSTALL_ROOT'] = '.'
     from subprocess import call
     call(['docs/setup_rtd_files.sh'])

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,11 @@ def install():
 def join_url(x, y):
     return '/' + '/'.join([z for z in x.split('/') + y.split('/') if z])
 
+def ensure_dir(f):
+    d = os.path.dirname(f)
+    if not os.path.exists(d):
+        os.makedirs(d)
+
 conf_path = config.CONF_PATH
 install_path = config.INSTALL_PATH
 
@@ -64,7 +69,8 @@ if install() and os.environ.get('READTHEDOCS'):
     print 'Customizing install for ReadTheDocs.org build servers...'
     conf_path = '.' + conf_path
     install_path = '.' +  install_path
-    config.VERSION_FILE_PATH = '.' + config.VERSION_FILE_PATH
+    #config.VERSION_FILE_PATH = '.' + config.VERSION_FILE_PATH
+    os.environ('ZTPS_INSTALL_ROOT') = '.'
     from subprocess import call
     call(['docs/setup_rtd_files.sh'])
     packages.append('client')
@@ -158,6 +164,8 @@ setup(
 if install():
     custom_path = os.environ.get('ZTPS_INSTALL_ROOT')
     if custom_path:
-        shutil.copy('VERSION', join_url(custom_path, config.VERSION_FILE_PATH))
+        version_file =  join_url(custom_path, config.VERSION_FILE_PATH)
     else:
-        shutil.copy('VERSION', config.VERSION_FILE_PATH)
+        version_file =  config.VERSION_FILE_PATH
+    ensure_dir(version_file)
+    shutil.copy('VERSION', version_file)


### PR DESCRIPTION
* Override ZTPS_INSTALL_ROOT on ReadTheDocs to install everything under the current directory.
* Add a function to ensure that sub-paths exist before copying files.
* Remove some extraneous, trailing whitespace 