### PR TITLE
Disable gzip, deflate in HTTP and fix wsgi server docstring

### DIFF
--- a/client/bootstrap
+++ b/client/bootstrap
@@ -875,6 +875,8 @@ class Server(object):
                       payload=None, files=None):
         if headers is None:
             headers = {}
+        # Disable gzip, deflate so we can safely determine if space is available
+        headers[u'Accept-Encoding'] = None
         if files is None:
             files = []
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -226,7 +226,17 @@ Add a network (in this case 192.168.100.0/24) for servicing DHCP requests for ZT
       option routers 192.168.100.1;
       option domain-name-servers <ipaddr>;
       option domain-name "<org>";
-      option bootfile-name "http://<ztp_hostname_or_ip>:<port>/bootstrap";
+
+      # Only return the bootfile-name to Arista devices
+      class "Arista" {
+        match if substring(option vendor-class-identifier, 0, 6) = "Arista";
+        # Interesting bits:
+        # Relay agent IP address
+        # Option-82: Agent Information
+        #     Suboption 1: Circuit ID
+        #       Ex: 45:74:68:65:72:6e:65:74:31 ==> Ethernet1
+        option bootfile-name "http://<ztp_hostname_or_ip>:<port>/bootstrap";
+      }
     }
 
 Enable and start the dhcpd service

--- a/ztpserver/app.py
+++ b/ztpserver/app.py
@@ -105,11 +105,12 @@ def load_config(conf=None):
 
 def start_wsgiapp(config_file=None, debug=False):
     ''' Provides the entry point into the application for wsgi compliant
-    servers.   Accepts a single keyword argument ``conf``.   The ``conf``
-    keyword argument specifies the path the server configuration file.  The
-    default value is /etc/ztpserver/ztpserver.conf.
+    servers.   Accepts an optional argument ``config_file``.   The
+    ``config_file`` keyword argument specifies the path the server
+    configuration file.  The default value is /etc/ztpserver/ztpserver.conf.
 
-    :param conf: string path pointing to configuration file
+    :param config_file: string path pointing to configuration file
+    :param debug: boolean set debug level logging? (Default: False)
     :return: a wsgi application object
 
     '''


### PR DESCRIPTION
Do not advertise that we accept gzip, or deflate so we don't run into file size mismatches.  We need to verify the real size to ensure we bail out early if there is not enough free space on the node.

Closes #316