### PR TITLE
Fix issue 337 - min image version

### DIFF
--- a/actions/install_image
+++ b/actions/install_image
@@ -46,6 +46,8 @@ def main(attributes):
     Attributes:
         url: path to source image file
         version: EOS version of new image file
+        downgrade: Boolean - Should EOS images be downgraded to match?
+                   (Default: True)
 
     Special_attributes: 
         NODE: API object - see documentation for details
@@ -59,6 +61,7 @@ def main(attributes):
               attributes:
                 url: files/images/vEOS.swi
                 version: 4.13.5F
+                downgrade: true
               name: "validate image"
               onstart: "Starting to install image"
               onsuccess: "SUCCESS: 4.13.5F installed"
@@ -72,13 +75,29 @@ def main(attributes):
     if not url:
         raise Exception('Missing attribute(\'url\')')
 
+    downgrade = attributes.get('downgrade', True)
+
     version = attributes.get('version')
     if not version:
         raise Exception('Missing attribute(\'version\')')
 
     current_version = node.api_enable_cmds(['show version'])[0]['version']
     if current_version == version:
+        node.log_msg('install_image: nothing to do: '
+                     'already running the configured version')
         return
+
+    if downgrade is not True:
+        #cur_ver_t = tuple([int(''.join(list(filter(str.isdigit, n)))) for n in current_version.split('.')])
+        #ver_t = tuple([int(''.join(list(filter(str.isdigit, n)))) for n in version.split('.')])
+        #if curr_ver_t < ver_t:
+        #from distutils.version import LooseVersion
+        #if LooseVersion(version) < LooseVersion(current_version):
+        from pkg_resources import parse_version
+        if parse_version(version) < parse_version(current_version):
+            node.log_msg('install_image: nothing to do: '
+                         'downgrade disabled')
+            return
 
     image = 'EOS-%s.swi' % version
     try:

--- a/actions/install_image
+++ b/actions/install_image
@@ -81,24 +81,22 @@ def main(attributes):
     if not version:
         raise Exception('Missing attribute(\'version\')')
 
+    # Return if version matches
     current_version = node.api_enable_cmds(['show version'])[0]['version']
     if current_version == version:
         node.log_msg('install_image: nothing to do: '
                      'already running the configured version')
         return
 
+    # Don't downgrade images if flag is set
     if downgrade is not True:
-        #cur_ver_t = tuple([int(''.join(list(filter(str.isdigit, n)))) for n in current_version.split('.')])
-        #ver_t = tuple([int(''.join(list(filter(str.isdigit, n)))) for n in version.split('.')])
-        #if curr_ver_t < ver_t:
-        #from distutils.version import LooseVersion
-        #if LooseVersion(version) < LooseVersion(current_version):
         from pkg_resources import parse_version
         if parse_version(version) < parse_version(current_version):
             node.log_msg('install_image: nothing to do: '
                          'downgrade disabled')
             return
 
+    # In all other cases, copy the image
     image = 'EOS-%s.swi' % version
     try:
         node.retrieve_url(url, '%s/%s' % (node.flash(), image))

--- a/docs/cookbook/actions.rst
+++ b/docs/cookbook/actions.rst
@@ -379,6 +379,71 @@ script.
 
 
 
+
+Install a Specific EOS Image without downgrading newer systems
+--------------------------------------------------------------
+
+Objective
+^^^^^^^^^
+
+I want a specific (v)EOS version to be automatically installed when I provision
+my node but I don't want systems with newer EOS versions to be downgraded
+
+.. note:: This assumes that you've already downloaded the desired (v)EOS image
+          from `Arista <https://www.arista.com/en/support/software-download>`_.
+
+Solution
+^^^^^^^^
+
+Let's create a place on the ZTPServer to host some SWIs:
+
+.. code-block:: console
+
+  # Go to your data_root - by default it's /usr/share/ztpserver
+  admin@ztpserver:~# cd /usr/share/ztpserver
+
+  # Create an images directory
+  admin@ztpserver:~# mkdir -p files/images
+
+  # SCP your SWI into the images directory, name it whatever you like
+  admin@ztpserver:~# scp admin@otherhost:/tmp/vEOS.swi files/images/vEOS_4.14.5F.swi
+
+Now let's create a definition that performs the ``install_image`` action:
+
+.. code-block:: console
+
+  # Go to your data_root - by default it's /usr/share/ztpserver
+  admin@ztpserver:~# cd /usr/share/ztpserver
+
+  # Create a definition file
+  admin@ztpserver:~# vi definitions/tor-definition
+
+Add the following lines to your definition, changing values where needed.  Specifically note the ``downgrade: false`` attribute.
+
+.. code-block:: yaml
+
+  ---
+  name: static node definition
+  actions:
+    -
+      action: install_image
+      attributes:
+        downgrade: false
+        url: files/images/vEOS_4.17.1F.swi
+        version: 4.17.1F
+      name: "Install 4.17.1F"
+
+.. note:: The definition uses YAML syntax
+
+Explanation
+^^^^^^^^^^^
+
+The difference between this recipe and the one, above, is setting the ``downgrade`` attribute to ``false``.  When downgrades are disabled, an image will only be copied if the running image is older than the image in the ZTP configuration.
+
+.. end of Install a specific EOS image
+
+
+
 Install an Extension
 --------------------
 

--- a/test/actions/test_install_image.py
+++ b/test/actions/test_install_image.py
@@ -88,6 +88,8 @@ class SuccessTest(unittest.TestCase):
             print 'Error: %s' % bootstrap.error
             raise_exception(assertion)
         finally:
+            remove_file(image_file)
+            bootstrap.end_test()
 
     def test_no_downgrade(self):
         bootstrap = Bootstrap(ztps_default_config=True)

--- a/test/actions/test_install_image.py
+++ b/test/actions/test_install_image.py
@@ -88,7 +88,6 @@ class SuccessTest(unittest.TestCase):
             print 'Error: %s' % bootstrap.error
             raise_exception(assertion)
         finally:
-            remove_file(image_file)
             bootstrap.end_test()
 
     def test_no_downgrade(self):
@@ -107,7 +106,6 @@ class SuccessTest(unittest.TestCase):
                                            get_action('install_image'))
         bootstrap.ztps.set_action_response('startup_config_action',
                                            startup_config_action())
-        bootstrap.ztps.set_file_response(image, print_action())
         bootstrap.start_test()
 
         image_file = '%s/EOS-%s.swi' % (bootstrap.flash, version2)

--- a/test/actions/test_install_image.py
+++ b/test/actions/test_install_image.py
@@ -111,8 +111,8 @@ class SuccessTest(unittest.TestCase):
         image_file = '%s/EOS-%s.swi' % (bootstrap.flash, version2)
         try:
             self.failUnless(bootstrap.success())
-            self.failUnless(eapi_log()[-1] == 
-                            'install_image: nothing to do: downgrade disabled')
+            self.failUnless('install_image: nothing to do: downgrade disabled'
+                            in bootstrap.output)
         except AssertionError as assertion:
             print 'Output: %s' % bootstrap.output
             print 'Error: %s' % bootstrap.error


### PR DESCRIPTION
Closes #337.  No behavior change unless the `install_image` attribute `downgrade: false` is set, in which case `install_image` will log a message and return if the existing image is equal to or newer than the action's configured image.