### PR TITLE
Don't insert a blank line at the start of a file

### DIFF
--- a/client/bootstrap
+++ b/client/bootstrap
@@ -478,8 +478,14 @@ class Node(object):
         return os.path.isfile(RC_EOS)
 
     def _append_lines(self, filename, lines):
+        if os.path.exists(filename) and os.path.getsize(filename) > 0:
+            fileexists = True
+        else:
+            fileexists = False
+
         with open(filename, 'a') as output:
-            output.write('\n')
+            if fileexists:
+                output.write('\n')
             output.write('\n'.join(lines))
 
     @classmethod


### PR DESCRIPTION
When creating a new file _append_lines() would insert a '\n' before the
lines being added which causes a problem when creating a new file
requiring a shebang in the first line, such as rc.eos.Now we check if
the file exists and is > zero length before adding the '\n'.