### PR TITLE
Enhance install_image to determine architecture and version from URL,…

### DIFF
--- a/actions/install_image
+++ b/actions/install_image
@@ -112,11 +112,19 @@ def main(attributes):
             node.log_msg("install_image: nothing to do: downgrade disabled")
             return
 
-    # In all other cases, copy the image
-    image = "EOS-{}.swi".format(version)
-    try:
-        node.retrieve_url(url, "{}/{}".format(node.flash(), image))
-    except Exception as exc:
-        raise_from(RuntimeError("Unable to retrieve image file from URL"), exc)
+    # Determine architecture from URL
+    architecture = 'EOS64' if '64' in url else 'EOS32' if '32' in url else 'EOS'
 
-    node.api_enable_cmds(["install source flash:{}".format(image)])
+    # Use the full version string, assuming it ends with either 'F' or 'M'
+    filename = "{}-{}.swi".format(architecture, version)
+
+    # Remove any existing filename from the URL to avoid duplication
+    base_url = re.sub(r'EOS(32|64)-.*\.swi', '', url, flags=re.IGNORECASE)
+    final_url = "{}/{}".format(base_url.strip('/'), filename)
+
+    try:
+        node.retrieve_url(final_url, "/mnt/flash/{}".format(filename))
+    except Exception as exc:
+        raise RuntimeError("Unable to retrieve image file from URL: {}".format(exc))
+
+    node.api_enable_cmds(["install source flash:{}".format(filename)])


### PR DESCRIPTION
Images labelled with 32 or 64 should be copied on /mnt/flash with the correct name.

```
drwxrwx---+  2 root      eosadmin      16384 Mar 16  2022 lost+found
drwxrwxr-x+  2 root      eosadmin       4096 Mar 16  2022 Fossil
drwxrwxr-x+  2 root      eosadmin       4096 Mar 16  2022 fastpkttx.backup
drwxrwxrwx+  2 root      eosadmin       4096 Mar 16  2022 .checkpoints
-rw-rw-rw-+  1 root      eosadmin          0 Mar 16  2022 .assetTags
drwxrwxr-x+  3 root      eosadmin       4096 Mar 16  2022 schedule
-rw-rw-r--+  1 106904808 eosadmin 1117379109 Jan  5 10:22 EOS-4.27.11M.swi
drwxrwxr-x+  2 106904808 eosadmin       4096 Jan  5 11:21 .managed-config
-rwxrwxrwx+  1 root      eosadmin       2473 Apr 18 14:26 startup-config
-rwxrwxrwx+  1 root      eosadmin 1254919771 Apr 18 14:26 EOS32-4.29.7M.swi
drwxrwx---+  2 root      eosadmin       4096 Apr 18 14:26 .extensions
-rw-rw-r--+  1 root      eosadmin         29 Apr 18 14:26 boot-config
-r--r-x---+  1 root      eosadmin 1254919771 Apr 18 14:28 .boot-image.swi
drwxr-xr-x   1 root      root            140 Apr 18 14:28 ..
drwxrwxr-x+  3 root      eosadmin       4096 Apr 18 14:28 aboot
drwxrwxr-x+  2 root      eosadmin       4096 Apr 18 14:28 tpm-data
drwxrwx---+ 13 root      eosadmin       4096 Apr 18 14:28 .
-rw-rw-r--+  1 root      eosadmin       1278 Apr 18 14:28 SsuRestoreLegacy.log
-rw-rw-r--+  1 root      eosadmin       1278 Apr 18 14:28 SsuRestore.log
-rw-rw-r--+  1 root      eosadmin       2079 Apr 18 14:28 AsuFastPktTransmit.log
-rw-rw-r--+  1 root      eosadmin          0 Apr 18 14:29 zerotouch-config
drwxrwx---+  3 root      eosadmin       4096 Apr 18 14:29 debug
drwxrwxr-x+  3 root      eosadmin       4096 Apr 18 14:30 persist
```

show version:
```
Hardware version: 11.20
Serial number: JPE22042879
Hardware MAC address: c4ca.2b24.2f41
System MAC address: c4ca.2b24.2f41

Software image version: 4.29.7M
Architecture: i686
Internal build version: 4.29.7M-35658221.4297M
Internal build ID: b9978b0a-8b54-4195-9c83-99f4277ac709
Image format version: 3.0
Image optimization: Default
```

```
---
actions:
  -
    action: install_image
    always_execute: true
    attributes:
      url: files/images/EOS32-4.29.7M.swi
      version: 4.29.7M
    name: "Install 4.29.7M"
```

see #404 
