### PR TITLE
install_image change image to reference filename provided by url attribute

### DIFF
--- a/actions/install_image
+++ b/actions/install_image
@@ -67,6 +67,8 @@ def main(attributes):
         version: EOS version of new image file
         downgrade: Boolean - Should EOS images be downgraded to match?
                    (Default: True)
+        image_name_from_url: Boolean - Should EOS images be named from URL?
+                   (Default: False)
 
     Special_attributes:
         NODE: API object - see documentation for details

--- a/actions/install_image
+++ b/actions/install_image
@@ -113,7 +113,7 @@ def main(attributes):
             return
 
     # In all other cases, copy the image
-    image = "EOS-{}.swi".format(version)
+    image = url.split("/")[-1]
     try:
         node.retrieve_url(url, "{}/{}".format(node.flash(), image))
     except Exception as exc:

--- a/actions/install_image
+++ b/actions/install_image
@@ -90,6 +90,7 @@ def main(attributes):
 
     node = attributes.get("NODE")
     url = attributes.get("url")
+    image_name_from_url = attributes.get("image_name_from_url", False)
 
     if not url:
         raise RuntimeError("Missing attribute('url')")
@@ -113,7 +114,11 @@ def main(attributes):
             return
 
     # In all other cases, copy the image
-    image = url.split("/")[-1]
+    if image_name_from_url:
+        image = url.split("/")[-1]
+    else:
+        image = "EOS-{}.swi".format(version)
+
     try:
         node.retrieve_url(url, "{}/{}".format(node.flash(), image))
     except Exception as exc:


### PR DESCRIPTION
In order to preserve 64 bit filenames (and perhaps others in the future) provided by Arista, I would like to suggest we extract the filename from the url variable rather than assemble filename via version variable.

There is an operational risk in my opinion whereas someone performing a firmware upgrade after ztp has provisioned the switch.  They will look at the filename and determine it is a 32bit image because it matches the name of the file provided by arista:

![image](https://github.com/arista-eosplus/ztpserver/assets/133690336/55ff2f44-ad83-4856-9942-22eae607aae3)

@Trailingslashes also has a take on this #405 

OG issue -> #404 




