### PR TITLE
Add compatibility for EOS 4.20.x

### DIFF
--- a/client/bootstrap
+++ b/client/bootstrap
@@ -348,6 +348,19 @@ sudo python setup.py install
 # pylint: enable=C0103
 # ------------------4.12.x support----------------------------
 
+# ------------------4.20.x support----------------------------
+
+import requests.models
+
+# patch Response to include __enter__/__exit__ for using within a context
+if not hasattr(requests.models.Response, '__enter__'):
+    requests.models.Response.__enter__ = lambda self: self
+
+if not hasattr(requests.models.Response, '__exit__'):
+    requests.models.Response.__exit__ = lambda self, *args: self.close()
+
+# ------------------4.20.x support----------------------------
+
 
 class ZtpError(Exception):
     pass


### PR DESCRIPTION
EOS 4.20 includes an older version of the requests module (1.2.3) that does not support python's context. This change patches the class with the methods required compatibility with the context decorator used within the bootstrap script.